### PR TITLE
Improve inline transcription editing workflow

### DIFF
--- a/app/static/styles/fileview.css
+++ b/app/static/styles/fileview.css
@@ -9,145 +9,384 @@
 }
 
 .file-title {
-    font-size: 2em;
-    font-weight: bold;
-    margin-bottom: 1em;
-    text-align: left;
+    font-size: 2.25em;
+    font-weight: 700;
+    margin-bottom: 0.2em;
 }
 
-.description-block .upload-time,
-.description-block .file-type {
-    margin-right: 1.5em;
-    font-weight: 500;
+.description {
+    margin: 0;
+    color: #cfcfcf;
 }
 
-.description-block .description {
-    margin-top: 0.5em;
-    color: #eee;
-}
-
-.container {
-    box-sizing: border-box;
-    margin: 0 auto;
-    margin-bottom: 40px;
-    background-color: rgba(255, 255, 255, 0.05);
-    padding: 2rem 3rem;
-    border-radius: 16px;
-    box-shadow: 0 0 20px rgba(0, 0, 0, 0.2);
+.page-header {
     display: flex;
-    gap: 1em;
-    align-items: stretch;
-    overflow-x: auto;
-    width: 100%;
+    justify-content: space-between;
+    align-items: flex-start;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+    margin-bottom: 2rem;
 }
 
-.pdf-viewer {
-    flex: 1;
-    background-color: #ccc;
-    color: #353535;
-    padding: 1em;
-    border-radius: 12px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.4);
+.header-actions {
     display: flex;
-    flex-direction: column;
-    min-width: 0;
+    gap: 1rem;
 }
 
-.pdf-canvas {
-    width: 100%;
-    min-height: 600px;
-    border: 1px solid #444;
-    border-radius: 8px;
-    background-color: white;
-    display: block;
-    margin: 0 auto;
-}
-
-.pdf-controller {
-    margin-top: 1em;
-    display: flex;
-    gap: 0.5em;
-    flex-wrap: nowrap;
+.btn {
+    display: inline-flex;
     align-items: center;
     justify-content: center;
+    padding: 0.75rem 1.5rem;
+    border-radius: 8px;
+    background: linear-gradient(135deg, #444, #1f1f1f);
+    color: #f5f5f5;
+    text-decoration: none;
+    font-weight: 600;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, opacity 0.2s ease;
+    box-shadow: 0 6px 20px rgba(0, 0, 0, 0.35);
+}
+
+.btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.45);
+}
+
+.btn.disabled {
+    pointer-events: none;
+    opacity: 0.45;
+}
+
+.viewer-editor {
+    display: flex;
+    gap: 2rem;
     flex-wrap: wrap;
 }
 
-button {
-    margin: 12px;
-    height: 50px;
-    min-width: 100px;
-    flex: 1 1 auto;
-    max-width: 200px;
-    border-radius: 10px;
-    background: #333;
-    justify-content: center;
-    align-items: center;
-    box-shadow: -5px -5px 15px #444, 5px 5px 15px #222,
-        inset 5px 5px 10px #444, inset -5px -5px 10px #222;
-    font-family: "Damion", cursive;
-    cursor: pointer;
-    border: none;
-    font-size: 16px;
-    color: rgb(161, 161, 161);
-    transition: 500ms;
-}
-
-button:hover {
-    box-shadow: -5px -5px 15px #444, 5px 5px 15px #222, inset 5px 5px 10px #222,
-        inset -5px -5px 10px #444;
-    color: #d6d6d6;
-    transition: 500ms;
-}
-
-
-
-/* From Uiverse.io by Cksunandh */
-.pdf-controller .input {
-    margin: 30px;
-    background: #333;
-    border: 1px solid #353535;
-    outline: none;
-    max-width: 200px;
-    padding: 11px 23px;
-    font-size: 16px;
-    border-radius: 50px;
-    color: rgb(161, 161, 161);
-    box-shadow: -5px -5px 15px #444, 5px 5px 15px #222, inset 5px 5px 10px #444,
-        inset -5px -5px 10px #222;
-}
-
-.ocr-box {
-    background-color: #2c2c2c;
-    padding: 1rem;
-    border-radius: 12px;
-    box-shadow: 0 0 10px rgba(0, 0, 0, 0.2);
-    overflow: hidden;
+.pdf-viewer {
+    flex: 1 1 480px;
+    background: rgba(255, 255, 255, 0.04);
+    border-radius: 16px;
+    padding: 1.5rem;
+    box-shadow: 0 0 20px rgba(0, 0, 0, 0.35);
     display: flex;
     flex-direction: column;
+    gap: 1rem;
+}
+
+.pdf-stage-wrapper {
+    position: relative;
+    width: 100%;
+    overflow: hidden;
+    background: #111;
+    border-radius: 12px;
+}
+
+.pdf-stage {
+    position: relative;
+    width: 100%;
+    height: 0;
+    padding-bottom: var(--pdf-aspect, 141%);
+    transform-origin: center center;
+    touch-action: none;
+}
+
+#pdf-image {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    object-fit: contain;
+    user-select: none;
+    pointer-events: none;
+}
+
+
+.highlight-overlay {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+}
+
+.line-box {
+    position: absolute;
+    border: 2px solid rgba(247, 181, 0, 0.45);
+    background: rgba(247, 181, 0, 0.18);
+    border-radius: 5px;
+    transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.line-box.active {
+    border-color: rgba(247, 181, 0, 0.95);
+    background: rgba(247, 181, 0, 0.35);
+    box-shadow: 0 0 18px rgba(247, 181, 0, 0.45);
+}
+
+.pdf-overlay-controls {
+    position: absolute;
+    top: 1rem;
+    right: 1rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    pointer-events: none;
+    z-index: 2;
+}
+
+.pdf-overlay-controls .control-group {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: rgba(0, 0, 0, 0.55);
+    border-radius: 999px;
+    padding: 0.35rem 0.6rem;
+    backdrop-filter: blur(6px);
+    box-shadow: 0 6px 15px rgba(0, 0, 0, 0.35);
+    pointer-events: auto;
+}
+
+.pdf-overlay-controls .control-group.pages {
+    border-radius: 14px;
+    padding: 0.35rem 0.85rem;
+}
+
+.control-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 2.4rem;
+    height: 2.4rem;
+    background: linear-gradient(135deg, rgba(255, 255, 255, 0.08), rgba(255, 255, 255, 0.02));
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    border-radius: 50%;
+    color: #f5f5f5;
+    text-decoration: none;
+    font-size: 1.25rem;
+    transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+    cursor: pointer;
+}
+
+.control-group.zoom .control-button:nth-child(2) {
+    width: 2.8rem;
+    border-radius: 999px;
+}
+
+.control-button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.4);
+    border-color: rgba(255, 255, 255, 0.35);
+}
+
+.control-button.disabled,
+.control-button.disabled:hover {
+    opacity: 0.45;
+    cursor: default;
+    transform: none;
+    box-shadow: none;
+    border-color: rgba(255, 255, 255, 0.1);
+}
+
+.control-group.pages .page-indicator {
+    margin: 0 0.5rem;
+    font-size: 0.95rem;
+    font-weight: 600;
+    white-space: nowrap;
+    color: #f0f0f0;
+}
+
+#save-transcription {
+    background: #2c2c2c;
+    border: none;
+    color: #eee;
+    padding: 0.65rem 1.25rem;
+    border-radius: 10px;
+    font-size: 0.95rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.2s ease, transform 0.2s ease;
+    box-shadow: inset 3px 3px 6px rgba(0, 0, 0, 0.5), inset -3px -3px 6px rgba(80, 80, 80, 0.35);
+}
+
+#save-transcription:hover {
+    background: #404040;
+    transform: translateY(-1px);
+}
+
+.transcription-panel {
+    flex: 1 1 420px;
+    background: rgba(255, 255, 255, 0.04);
+    border-radius: 16px;
+    padding: 1.5rem;
+    box-shadow: 0 0 20px rgba(0, 0, 0, 0.35);
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+}
+
+.panel-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.transcription-lines {
+    max-height: 420px;
+    overflow-y: auto;
+    background: #161616;
+    border-radius: 12px;
+    padding: 1rem;
+    border: 1px solid #2f2f2f;
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+}
+
+.transcription-line {
+    position: relative;
+    padding: 0.6rem 0.75rem;
+    border-radius: 10px;
+    transition: background 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+    cursor: pointer;
+    border: 1px solid transparent;
+    display: flex;
+    align-items: flex-start;
+    gap: 0.75rem;
+}
+
+.transcription-line:hover {
+    background: rgba(255, 255, 255, 0.06);
+}
+
+.transcription-line.active {
+    background: rgba(247, 181, 0, 0.15);
+    border-color: rgba(247, 181, 0, 0.6);
+    box-shadow: 0 0 12px rgba(247, 181, 0, 0.2);
+}
+
+.line-text {
     flex: 1;
-    min-width: 0;
-}
-
-.ocr-box h2 {
-    margin-top: 0;
-    font-size: 1.2rem;
-    margin-bottom: 1rem;
-    color: #ffffff;
-}
-
-.transcripts {
-    white-space: pre-wrap;
+    color: #f5f5f5;
     font-family: 'Courier New', monospace;
     font-size: 0.95rem;
-    color: #ddd;
-    line-height: 1.6;
-    overflow-y: auto;
-    flex: 1;
+    white-space: pre-wrap;
+    word-break: break-word;
 }
 
-.transcripts b,
-.transcripts strong {
-    font-weight: bold;
-    color:red;
+.transcription-line.is-empty .line-text {
+    color: #999;
+    font-style: italic;
+}
+
+.transcription-line.is-empty .line-text::before {
+    content: '(blank line)';
+}
+
+.line-editor {
+    display: none;
+    width: 100%;
+    background: #111;
+    border: 1px solid #444;
+    color: #f5f5f5;
+    border-radius: 8px;
+    font-family: 'Courier New', monospace;
+    font-size: 0.95rem;
+    padding: 0.45rem 0.6rem;
+    resize: none;
+    min-height: 32px;
+    line-height: 1.5;
+}
+
+.transcription-line.editing .line-text {
+    display: none;
+}
+
+.transcription-line.editing .line-editor {
+    display: block;
+}
+
+.line-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+    margin-left: auto;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+}
+
+.transcription-line.active .line-actions,
+.transcription-line.editing .line-actions {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.icon-button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 1.9rem;
+    height: 1.9rem;
+    border-radius: 50%;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+    background: rgba(0, 0, 0, 0.45);
+    color: #f5f5f5;
+    cursor: pointer;
+    transition: transform 0.2s ease, border-color 0.2s ease, background-color 0.2s ease;
+    font-size: 0.9rem;
+    padding: 0;
+}
+
+.icon-button:hover {
+    transform: translateY(-1px);
+    border-color: rgba(255, 255, 255, 0.4);
+    background: rgba(30, 30, 30, 0.75);
+}
+
+.icon-button.hidden {
+    display: none;
+}
+
+.icon-button.cancel {
+    color: #f98e8e;
+}
+
+.icon-button.confirm {
+    color: #a3f7b5;
+}
+
+.panel-subtext {
+    margin: 0;
+    font-size: 0.9rem;
+    color: #cfcfcf;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}
+
+@media (max-width: 992px) {
+    .viewer-editor {
+        flex-direction: column;
+    }
+
+    .pdf-overlay-controls {
+        top: 0.75rem;
+        right: 0.75rem;
+    }
+
+    .control-button {
+        width: 2.1rem;
+        height: 2.1rem;
+        font-size: 1.05rem;
+    }
 }

--- a/app/templates/FileView.html
+++ b/app/templates/FileView.html
@@ -6,34 +6,436 @@
 
 {% block content %}
   <div class="main-box">
-    <h1 class="file-title">File: {{ name }}</h1>
-    <div class="description-block">
-      <p class="description">Description: {{ description }}</p>
+    <div class="page-header">
+      <div>
+        <h1 class="file-title">File: {{ name }}</h1>
+        <p class="description">{{ description }}</p>
+      </div>
+      <div class="header-actions">
+        <a class="btn" href="{{ url_for('main.download_transcription', file_id=file_id) }}">Download Text</a>
+      </div>
     </div>
 
-    <div class="container" style="display: flex; gap: 40px;">
-      <div class="ocr-image-box" style="flex: 1; text-align: center;">
-        <img src="data:image/png;base64,{{ image }}" alt="Page image" style="max-width: 100%; height: auto;" />
-        <div class="pdf-controller" style="margin-top:10px;">
-          {% if page > 1 %}
-            <a href="{{ url_for('main.file_view', file_id=file_id, page=page-1) }}">&laquo; Prev</a>
+    <div class="viewer-editor">
+      <div class="pdf-viewer">
+        <div class="pdf-stage-wrapper">
+          {% if image_dimensions %}
+            {% set aspect = (image_dimensions.height / image_dimensions.width * 100) %}
           {% else %}
-            <span style="color: #ccc;">&laquo; Prev</span>
+            {% set aspect = None %}
           {% endif %}
-          <span>Page {{ page }} of {{ total_pages }}</span>
-          {% if page < total_pages %}
-            <a href="{{ url_for('main.file_view', file_id=file_id, page=page+1) }}">Next &raquo;</a>
-          {% else %}
-            <span style="color: #ccc;">Next &raquo;</span>
-          {% endif %}
+          <div id="pdf-stage" class="pdf-stage" {% if aspect %}style="--pdf-aspect: {{ '%.2f'|format(aspect) }}%;"{% endif %}>
+            <img id="pdf-image" src="data:image/png;base64,{{ image }}" alt="Page image" />
+            <div id="highlight-overlay" class="highlight-overlay"></div>
+          </div>
+          <div class="pdf-overlay-controls" role="group" aria-label="PDF viewer controls">
+            <div class="control-group zoom">
+              <button type="button" id="zoom-out" class="control-button" title="Zoom out">
+                <span aria-hidden="true">−</span>
+                <span class="sr-only">Zoom out</span>
+              </button>
+              <button type="button" id="reset-view" class="control-button" title="Fit to screen">
+                <span aria-hidden="true">⤢</span>
+                <span class="sr-only">Fit view</span>
+              </button>
+              <button type="button" id="zoom-in" class="control-button" title="Zoom in">
+                <span aria-hidden="true">+</span>
+                <span class="sr-only">Zoom in</span>
+              </button>
+            </div>
+            <div class="control-group pages">
+              {% if page > 1 %}
+                <a class="control-button" href="{{ url_for('main.file_view', file_id=file_id, page=page-1) }}" title="Previous page">
+                  <span aria-hidden="true">◀</span>
+                  <span class="sr-only">Previous page</span>
+                </a>
+              {% else %}
+                <span class="control-button disabled" aria-disabled="true">
+                  <span aria-hidden="true">◀</span>
+                  <span class="sr-only">Previous page</span>
+                </span>
+              {% endif %}
+              <span class="page-indicator">Page {{ page }} of {{ total_pages }}</span>
+              {% if page < total_pages %}
+                <a class="control-button" href="{{ url_for('main.file_view', file_id=file_id, page=page+1) }}" title="Next page">
+                  <span aria-hidden="true">▶</span>
+                  <span class="sr-only">Next page</span>
+                </a>
+              {% else %}
+                <span class="control-button disabled" aria-disabled="true">
+                  <span aria-hidden="true">▶</span>
+                  <span class="sr-only">Next page</span>
+                </span>
+              {% endif %}
+            </div>
+          </div>
         </div>
       </div>
-      <div class="ocr-transcription-box" style="flex: 1;">
-        <h3>Transcription</h3>
-        <div class="transcripts" style="white-space: pre-wrap;">
-          {{ transcription | markdown_bold_to_html | safe }}
+
+      <div class="transcription-panel">
+        <div class="panel-header">
+          <h3>Transcription</h3>
+          <button type="button" id="save-transcription">Save Changes</button>
         </div>
+        <p class="panel-subtext">Double-click a line or use the edit icon to update the transcription. Selecting a different line or clicking outside will apply your edits.</p>
+        <div id="transcription-lines" class="transcription-lines" aria-live="polite"></div>
       </div>
     </div>
   </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/@panzoom/panzoom@4.5.1/dist/panzoom.min.js" integrity="sha256-8nZx09te43Q6rY7DKY2YgDD10GpS1Ry6j8TDIrS9azI=" crossorigin="anonymous"></script>
+  <script>
+    const lineBoxesData = {{ line_boxes | tojson }};
+    const initialLines = {{ transcription_lines | tojson }};
+    const fileId = {{ file_id }};
+    const pageNumber = {{ page }};
+
+    const pdfStage = document.getElementById('pdf-stage');
+    const highlightOverlay = document.getElementById('highlight-overlay');
+    const saveButton = document.getElementById('save-transcription');
+    const transcriptionLinesContainer = document.getElementById('transcription-lines');
+    const panzoomInstance = Panzoom(pdfStage, {
+      contain: 'outside',
+      maxScale: 4,
+      minScale: 0.5,
+      cursor: 'grab'
+    });
+
+    pdfStage.parentElement.addEventListener('wheel', panzoomInstance.zoomWithWheel, { passive: true });
+
+    document.getElementById('zoom-in').addEventListener('click', (event) => {
+      event.preventDefault();
+      panzoomInstance.zoomIn();
+    });
+    document.getElementById('zoom-out').addEventListener('click', (event) => {
+      event.preventDefault();
+      panzoomInstance.zoomOut();
+    });
+    document.getElementById('reset-view').addEventListener('click', (event) => {
+      event.preventDefault();
+      panzoomInstance.reset();
+    });
+
+    const linesState = Array.isArray(initialLines) ? [...initialLines] : [];
+    if (linesState.length === 0) {
+      linesState.push('');
+    }
+    const lineBoxes = Array.isArray(lineBoxesData) ? [...lineBoxesData] : [];
+    const lineElements = [];
+    const overlayRects = [];
+
+    let activeLineIndex = null;
+    let editingLineIndex = null;
+    let editingOriginalText = '';
+
+    function ensureLineBoxesLength(count) {
+      if (lineBoxes.length < count) {
+        const missing = count - lineBoxes.length;
+        for (let i = 0; i < missing; i += 1) {
+          lineBoxes.push(null);
+        }
+      }
+    }
+
+    function autoSizeEditor(editor) {
+      if (!editor) {
+        return;
+      }
+      editor.style.height = 'auto';
+      editor.style.height = `${Math.max(editor.scrollHeight, 32)}px`;
+    }
+
+    function updateOverlayHighlight() {
+      overlayRects.forEach((rect, index) => {
+        if (!rect) {
+          return;
+        }
+        rect.classList.toggle('active', index === activeLineIndex);
+      });
+    }
+
+    function ensureLineVisible(index) {
+      const line = lineElements[index];
+      if (!line) {
+        return;
+      }
+      const containerRect = transcriptionLinesContainer.getBoundingClientRect();
+      const lineRect = line.container.getBoundingClientRect();
+      if (lineRect.top < containerRect.top || lineRect.bottom > containerRect.bottom) {
+        line.container.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      }
+    }
+
+    function activateLine(index) {
+      if (typeof index !== 'number' || Number.isNaN(index)) {
+        if (activeLineIndex !== null && lineElements[activeLineIndex]) {
+          lineElements[activeLineIndex].container.classList.remove('active');
+        }
+        activeLineIndex = null;
+        updateOverlayHighlight();
+        return;
+      }
+
+      if (editingLineIndex !== null && editingLineIndex !== index) {
+        finalizeEditing(true);
+      }
+
+      if (activeLineIndex !== null && lineElements[activeLineIndex]) {
+        lineElements[activeLineIndex].container.classList.remove('active');
+      }
+
+      activeLineIndex = index;
+      const line = lineElements[index];
+      if (line) {
+        line.container.classList.add('active');
+      }
+      updateOverlayHighlight();
+      ensureLineVisible(index);
+    }
+
+    function updateLineContent(index, text) {
+      const line = lineElements[index];
+      if (!line) {
+        return;
+      }
+      const value = text ?? '';
+      linesState[index] = value;
+      line.textWrapper.textContent = value;
+      line.container.classList.toggle('is-empty', value.trim().length === 0);
+      line.editor.value = value;
+      autoSizeEditor(line.editor);
+    }
+
+    function finalizeEditing(saveChanges) {
+      if (editingLineIndex === null) {
+        return;
+      }
+      const index = editingLineIndex;
+      const line = lineElements[index];
+      if (!line) {
+        editingLineIndex = null;
+        editingOriginalText = '';
+        return;
+      }
+
+      const shouldSave = saveChanges !== false;
+      const newValue = shouldSave ? line.editor.value : editingOriginalText;
+
+      line.container.classList.remove('editing');
+      line.editButton.classList.remove('hidden');
+      line.confirmButton.classList.add('hidden');
+      line.cancelButton.classList.add('hidden');
+      line.editor.blur();
+
+      if (!shouldSave) {
+        line.editor.value = editingOriginalText;
+      }
+
+      updateLineContent(index, newValue);
+
+      editingLineIndex = null;
+      editingOriginalText = '';
+    }
+
+    function beginEditing(index) {
+      const line = lineElements[index];
+      if (!line) {
+        return;
+      }
+
+      if (editingLineIndex !== null && editingLineIndex !== index) {
+        finalizeEditing(true);
+      }
+
+      activateLine(index);
+
+      editingLineIndex = index;
+      editingOriginalText = line.editor.value;
+
+      line.container.classList.add('editing');
+      line.editButton.classList.add('hidden');
+      line.confirmButton.classList.remove('hidden');
+      line.cancelButton.classList.remove('hidden');
+      autoSizeEditor(line.editor);
+      line.editor.focus({ preventScroll: true });
+      line.editor.setSelectionRange(line.editor.value.length, line.editor.value.length);
+    }
+
+    function registerLineEvents(line, index) {
+      line.container.addEventListener('click', (event) => {
+        if (event.target.closest('.icon-button')) {
+          return;
+        }
+        activateLine(index);
+      });
+
+      line.container.addEventListener('dblclick', (event) => {
+        event.preventDefault();
+        beginEditing(index);
+      });
+
+      line.editButton.addEventListener('click', (event) => {
+        event.stopPropagation();
+        beginEditing(index);
+      });
+
+      line.confirmButton.addEventListener('click', (event) => {
+        event.stopPropagation();
+        finalizeEditing(true);
+      });
+
+      line.cancelButton.addEventListener('click', (event) => {
+        event.stopPropagation();
+        finalizeEditing(false);
+      });
+
+      line.editor.addEventListener('keydown', (event) => {
+        if (event.key === 'Enter' && !event.shiftKey) {
+          event.preventDefault();
+          finalizeEditing(true);
+        } else if (event.key === 'Escape') {
+          event.preventDefault();
+          finalizeEditing(false);
+        }
+      });
+
+      line.editor.addEventListener('input', () => {
+        autoSizeEditor(line.editor);
+      });
+    }
+
+    function createLineElement(text, index) {
+      const container = document.createElement('div');
+      container.className = 'transcription-line';
+      container.dataset.lineIndex = index;
+
+      const textWrapper = document.createElement('div');
+      textWrapper.className = 'line-text';
+      container.appendChild(textWrapper);
+
+      const editor = document.createElement('textarea');
+      editor.className = 'line-editor';
+      editor.setAttribute('spellcheck', 'false');
+      editor.rows = 1;
+      container.appendChild(editor);
+
+      const actions = document.createElement('div');
+      actions.className = 'line-actions';
+
+      const editButton = document.createElement('button');
+      editButton.type = 'button';
+      editButton.className = 'icon-button edit';
+      editButton.innerHTML = '<span aria-hidden="true">✎</span><span class="sr-only">Edit line</span>';
+      actions.appendChild(editButton);
+
+      const confirmButton = document.createElement('button');
+      confirmButton.type = 'button';
+      confirmButton.className = 'icon-button confirm hidden';
+      confirmButton.innerHTML = '<span aria-hidden="true">✔</span><span class="sr-only">Save line</span>';
+      actions.appendChild(confirmButton);
+
+      const cancelButton = document.createElement('button');
+      cancelButton.type = 'button';
+      cancelButton.className = 'icon-button cancel hidden';
+      cancelButton.innerHTML = '<span aria-hidden="true">✕</span><span class="sr-only">Discard changes</span>';
+      actions.appendChild(cancelButton);
+
+      container.appendChild(actions);
+
+      transcriptionLinesContainer.appendChild(container);
+
+      const line = {
+        container,
+        textWrapper,
+        editor,
+        editButton,
+        confirmButton,
+        cancelButton,
+      };
+
+      registerLineEvents(line, index);
+
+      return line;
+    }
+
+    function renderOverlayBoxes() {
+      highlightOverlay.innerHTML = '';
+      lineBoxes.forEach((box, index) => {
+        if (!box) {
+          overlayRects[index] = null;
+          return;
+        }
+        const rect = document.createElement('div');
+        rect.className = 'line-box';
+        rect.style.left = `${box.x * 100}%`;
+        rect.style.top = `${box.y * 100}%`;
+        rect.style.width = `${box.width * 100}%`;
+        rect.style.height = `${box.height * 100}%`;
+        rect.dataset.lineIndex = index;
+        highlightOverlay.appendChild(rect);
+        overlayRects[index] = rect;
+      });
+      updateOverlayHighlight();
+    }
+
+    function buildTranscriptionLines() {
+      transcriptionLinesContainer.innerHTML = '';
+      lineElements.length = 0;
+      ensureLineBoxesLength(linesState.length);
+      linesState.forEach((line, index) => {
+        const lineObj = createLineElement(line, index);
+        lineElements[index] = lineObj;
+        updateLineContent(index, line);
+      });
+    }
+
+    saveButton.addEventListener('click', async () => {
+      if (editingLineIndex !== null) {
+        finalizeEditing(true);
+      }
+
+      saveButton.disabled = true;
+      saveButton.textContent = 'Saving...';
+
+      const payload = linesState.join('\n');
+
+      try {
+        const response = await fetch(`/api/files/${fileId}/pages/${pageNumber}/transcription`, {
+          method: 'PUT',
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: JSON.stringify({ transcription: payload })
+        });
+        if (!response.ok) {
+          throw new Error('Failed to save transcription');
+        }
+        saveButton.textContent = 'Saved!';
+      } catch (error) {
+        console.error(error);
+        saveButton.textContent = 'Error - Retry';
+      } finally {
+        setTimeout(() => {
+          saveButton.disabled = false;
+          saveButton.textContent = 'Save Changes';
+        }, 1500);
+      }
+    });
+
+    document.addEventListener('click', (event) => {
+      const clickedInsideLines = transcriptionLinesContainer.contains(event.target);
+      if (!clickedInsideLines) {
+        if (editingLineIndex !== null) {
+          finalizeEditing(true);
+        }
+        if (!event.target.closest('.pdf-overlay-controls')) {
+          activateLine(null);
+        }
+      }
+    });
+
+    ensureLineBoxesLength(linesState.length);
+    buildTranscriptionLines();
+    renderOverlayBoxes();
+  </script>
 {% endblock %}

--- a/app/utils/text_regions.py
+++ b/app/utils/text_regions.py
@@ -1,0 +1,75 @@
+import io
+from typing import List, Optional, Dict
+
+import cv2
+import numpy as np
+from PIL import Image
+
+
+def _load_image_from_bytes(image_bytes: bytes) -> Optional[np.ndarray]:
+    """Decode image bytes into an OpenCV BGR image."""
+    if not image_bytes:
+        return None
+    image_array = np.frombuffer(image_bytes, dtype=np.uint8)
+    if image_array.size == 0:
+        return None
+    image = cv2.imdecode(image_array, cv2.IMREAD_COLOR)
+    return image
+
+
+def extract_line_boxes(image_bytes: bytes, *, min_area: int = 2000) -> List[Dict[str, float]]:
+    """Return approximate bounding boxes (normalized) for lines of text.
+
+    The detection is intentionally model-agnostic so the coordinates can be reused
+    regardless of which transcription engine produced the text.
+    """
+    image = _load_image_from_bytes(image_bytes)
+    if image is None:
+        return []
+
+    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    gray = cv2.GaussianBlur(gray, (5, 5), 0)
+
+    # Binarize using Otsu's method. Invert so that text is white on black.
+    _, thresh = cv2.threshold(gray, 0, 255, cv2.THRESH_BINARY + cv2.THRESH_OTSU)
+    thresh = 255 - thresh
+
+    # Connect characters along a line.
+    kernel = cv2.getStructuringElement(cv2.MORPH_RECT, (35, 7))
+    dilated = cv2.dilate(thresh, kernel, iterations=1)
+
+    contours, _ = cv2.findContours(dilated, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+
+    height, width = image.shape[:2]
+    boxes: List[Dict[str, float]] = []
+
+    for contour in contours:
+        x, y, w, h = cv2.boundingRect(contour)
+        area = w * h
+        if area < min_area:
+            continue
+        pad = int(0.02 * max(w, h))
+        x = max(x - pad, 0)
+        y = max(y - pad, 0)
+        w = min(w + 2 * pad, width - x)
+        h = min(h + 2 * pad, height - y)
+        boxes.append(
+            {
+                "x": x / width,
+                "y": y / height,
+                "width": w / width,
+                "height": h / height,
+            }
+        )
+
+    boxes.sort(key=lambda b: (b["y"], b["x"]))
+    return boxes
+
+
+def get_image_dimensions(image_bytes: bytes) -> Optional[Dict[str, int]]:
+    try:
+        with Image.open(io.BytesIO(image_bytes)) as img:
+            width, height = img.size
+            return {"width": width, "height": height}
+    except Exception:
+        return None


### PR DESCRIPTION
## Summary
- replace the viewer controls with an in-stage overlay and persistent highlight boxes for every detected line
- rebuild the transcription panel around clickable, inline-editable lines with edit/confirm/cancel affordances
- synchronize selection, editing, and saving logic so changes apply when switching focus or clicking away

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68ef27e126148330865d6442084eacad