### PR TITLE
Restore baseline file view and surface detected text regions

### DIFF
--- a/app/main/routes.py
+++ b/app/main/routes.py
@@ -7,6 +7,7 @@ from app.models import UploadedFile
 from config import Config
 from .utils import pdf_to_images_base64
 from app.utils.ocr_engine import run_ocr_engine
+from app.utils.text_regions import extract_text_regions
 import base64
 from app.models import UploadedFile, FilePage
 from dotenv import load_dotenv
@@ -130,8 +131,10 @@ def file_view(file_id):
         page = 1
 
     current_page = pages[page - 1]
-    image_base64 = base64.b64encode(current_page.image).decode("utf-8")
+    image_bytes = current_page.image
+    image_base64 = base64.b64encode(image_bytes).decode("utf-8")
     transcription = current_page.transcription or "No transcription available."
+    text_regions = extract_text_regions(image_bytes)
 
     return render_template(
         "FileView.html",
@@ -142,6 +145,7 @@ def file_view(file_id):
         transcription=transcription,
         page=page,
         total_pages=total_pages,
+        text_regions=text_regions,
     )
 
 @bp.route("/search", methods=["GET"])

--- a/app/static/styles/fileview.css
+++ b/app/static/styles/fileview.css
@@ -41,6 +41,27 @@
     width: 100%;
 }
 
+.ocr-image-stage {
+    position: relative;
+    display: inline-block;
+    max-width: 100%;
+}
+
+.ocr-image {
+    display: block;
+    max-width: 100%;
+    height: auto;
+    border-radius: 8px;
+}
+
+.ocr-text-region {
+    position: absolute;
+    border: 2px solid rgba(255, 193, 7, 0.85);
+    background-color: rgba(255, 193, 7, 0.25);
+    border-radius: 4px;
+    pointer-events: none;
+}
+
 .pdf-viewer {
     flex: 1;
     background-color: #ccc;

--- a/app/templates/FileView.html
+++ b/app/templates/FileView.html
@@ -13,7 +13,22 @@
 
     <div class="container" style="display: flex; gap: 40px;">
       <div class="ocr-image-box" style="flex: 1; text-align: center;">
-        <img src="data:image/png;base64,{{ image }}" alt="Page image" style="max-width: 100%; height: auto;" />
+        <div class="ocr-image-stage">
+          <img class="ocr-image" src="data:image/png;base64,{{ image }}" alt="Page image" />
+          {% if text_regions %}
+            {% for region in text_regions %}
+              <div
+                class="ocr-text-region"
+                style="
+                  top: {{ (region.top * 100)|round(3) }}%;
+                  left: {{ (region.left * 100)|round(3) }}%;
+                  width: {{ (region.width * 100)|round(3) }}%;
+                  height: {{ (region.height * 100)|round(3) }}%;
+                "
+              ></div>
+            {% endfor %}
+          {% endif %}
+        </div>
         <div class="pdf-controller" style="margin-top:10px;">
           {% if page > 1 %}
             <a href="{{ url_for('main.file_view', file_id=file_id, page=page-1) }}">&laquo; Prev</a>

--- a/app/utils/text_regions.py
+++ b/app/utils/text_regions.py
@@ -1,0 +1,63 @@
+import io
+from typing import Dict, List
+
+try:
+    import cv2 as cv  # type: ignore
+except Exception:  # pragma: no cover - gracefully degrade if OpenCV is unavailable
+    cv = None  # type: ignore
+
+import numpy as np
+from PIL import Image
+
+
+def extract_text_regions(image_bytes: bytes) -> List[Dict[str, float]]:
+    """Return normalized bounding boxes for prominent text regions.
+
+    The boxes are normalized to the image width/height so the caller can
+    overlay them regardless of the rendered size on the page.
+    """
+
+    if not image_bytes or cv is None:
+        return []
+
+    with Image.open(io.BytesIO(image_bytes)) as image:
+        rgb_image = image.convert("RGB")
+        np_image = np.array(rgb_image)
+
+    gray = cv.cvtColor(np_image, cv.COLOR_RGB2GRAY)
+
+    # Smooth noise and emphasise darker text on lighter backgrounds.
+    blurred = cv.GaussianBlur(gray, (5, 5), 0)
+    _, thresh = cv.threshold(blurred, 0, 255, cv.THRESH_BINARY + cv.THRESH_OTSU)
+
+    # Invert so text areas are white to help dilation join characters.
+    inverted = cv.bitwise_not(thresh)
+
+    # Merge characters within the same line into single contours.
+    line_kernel = cv.getStructuringElement(cv.MORPH_RECT, (60, 10))
+    dilated = cv.dilate(inverted, line_kernel, iterations=2)
+
+    contours, _ = cv.findContours(dilated, cv.RETR_EXTERNAL, cv.CHAIN_APPROX_SIMPLE)
+
+    height, width = gray.shape
+    min_area = 0.0005 * width * height
+    max_area = 0.9 * width * height
+
+    boxes: List[Dict[str, float]] = []
+    for contour in contours:
+        x, y, w, h = cv.boundingRect(contour)
+        area = w * h
+        if area < min_area or area > max_area:
+            continue
+
+        boxes.append(
+            {
+                "left": x / width,
+                "top": y / height,
+                "width": w / width,
+                "height": h / height,
+            }
+        )
+
+    boxes.sort(key=lambda box: (box["top"], box["left"]))
+    return boxes


### PR DESCRIPTION
## Summary
- revert the prior interactive workspace changes that regressed the transcription display
- add an OpenCV-powered helper to derive normalized text region boxes from each scanned page
- render the detected regions as translucent overlays on top of the PDF image so the line detection can be verified
- guard the text-region extraction so missing OpenCV system libraries no longer break the viewer

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_e_68ef27e126148330865d6442084eacad